### PR TITLE
replaced GNU getopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__/
 *.exe
 *.out
 *.app
+
+# Tags file
+tags

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ SRCS := src/main.c                     \
         src/token.c                    \
         src/tree.c                     \
         src/scanner.c                  \
-        src/parse.c
+        src/parse.c		       \
+        src/option.c
 
 all: $(BUILD_ROOT) $(BUILD_TARGET)
 

--- a/src/option.c
+++ b/src/option.c
@@ -1,0 +1,79 @@
+#include <string.h>
+
+#include "option.h"
+
+// internal globals
+static const struct option *_g_option_opts;
+static char *_g_arg_ptr;
+static char **_g_option_argv;
+
+// exposed global for OPTION_OPERAND option
+char *option_operand;
+// exposed global for OPTION_UNKNOWN option
+char *option_unknown_opt;
+
+//
+// option_setopts - set internal globals to point to opts and argv
+//
+void option_setopts(const struct option *opts, char **argv) {
+        _g_option_argv = argv;
+        _g_option_opts = opts;
+}
+
+//
+// option_nextopt - get the .id field from the next option in the opts array
+//
+int option_nextopt(void) {
+        if (*_g_option_argv != NULL) {
+                ++_g_option_argv;
+        } else {
+                return 0;
+        }
+
+        char **optstr_p = _g_option_argv;
+        if (*optstr_p == NULL) {
+                return 0;
+        }
+
+        const struct option *p = _g_option_opts;
+        while (p->id != 0) {
+                if (!strcmp(*optstr_p, p->name)) {
+                        if (p->has_args) {
+                                _g_arg_ptr = optstr_p[1];
+                                ++_g_option_argv;
+                        }
+
+                        return p->id;
+                } else if (**optstr_p != '-') {
+                        option_operand = *optstr_p;
+                        return OPTION_OPERAND;
+                }
+
+                ++p;
+        }
+
+        option_unknown_opt = *optstr_p;
+        return OPTION_UNKNOWN;
+}
+
+//
+// option_nextarg - get the next argument from the last option with arguments
+//
+char *option_nextarg(void) {
+        char *arg = _g_arg_ptr;
+        char *arg_p = arg;
+
+        while (*arg_p != '\0' && *arg_p != ',') {
+                ++arg_p;
+        }
+
+        if (*arg_p == '\0') {
+                _g_arg_ptr = arg_p;
+                return arg;
+        }
+
+        _g_arg_ptr = arg_p + 1;
+        *arg_p = '\0';
+
+        return arg;
+}

--- a/src/option.h
+++ b/src/option.h
@@ -1,0 +1,20 @@
+#ifndef __OPTION_H__
+        #define __OPTION_H__
+
+        #include <stdbool.h>
+
+        enum {OPTION_UNKNOWN = -2, OPTION_OPERAND = -3};
+
+        struct option {
+                char *name;
+                int id;
+                bool has_args;
+        };
+
+        extern char *option_operand;
+        extern char *option_unknown_opt;
+
+        extern void option_setopts(const struct option *opts, char **argv);
+        extern int option_nextopt(void);
+        extern char *option_nextarg(void);
+#endif


### PR DESCRIPTION
GNU getopt has been replaced by a hand-rolled implementation, details on usage are as follows.
<br>
```c
void option_setopts(const struct option *opts, char **argv)
```
`opts` : address of the first `struct option` in an array of `struct options` which is terminated with a `struct option` whose fields are all zero.
`argv` : a `NULL`-terminated array of `char*s`, typically `argv`.

`option_setopts` initialises values internal to the options library and must be called before any other functions from `options.c`.
An example opts array:
```c
enum {
    OPT_INPUT,
    OPT_OUTPUT,
    OPT_HELP,
};

static const struct option opts[] = {
    {"--input", OPT_INPUT, true},
    {"--output", OPT_OUTPUT, true},
    {"-h", OPT_HELP, false},

    (struct option){0},
};
```
The first member of each `struct option` is the option name, the second is the integer value which will be returned from `options_nextopt` when it is found in `argv`, the third is a boolean value indicating whether the option is expected to occur in `argv` before a comma-separated list of arguments (e.g. `--input first,second,third`).

The final element of the opts array, `(struct option){0}, is the required zero-valued struct to terminate the array`.
<br><br><br>
```c
int option_nextopt(void)
```
`option_nextopt` consumes a `char*` from `argv` array and returns the `.id` field of the corresponding `struct option` as specified in the `opts` array. Returns `0` if the end of `argv` has been reached.
<br><br><br>
```c
char *option_nextarg(void)
```
`option_nextarg` consumes and returns an argument from the comma-separated argument list in `argv` following an option taking arguments. Returns a pointer to a null byte if the end of the argument list has been reached. Do not call before an argument-taking option has been found in `argv`.

Example usage:
```c
                if (option_nextopt() == OPT_INPUTS) {
                        char *arg;
                        while (*(arg = option_nextarg())) {
                                *inputs++ = arg;
                        }
                }
```
<br><br><br>
```c
char *option_operand;
```
`option_operand` is a global `char*` declared in `options.c` and set when an option is found in `argv` which does not begin with the `-` character. When such an option is found by `option_nextopt` it sets `option_operand` to point to the option in `argv` and returns `OPTION_OPERAND` which is a negative value.

Example usage:
```c
        if (option_nextopt() == OPTION_OPERAND) {
            filename = option_operand;
            break;
        }
```
<br><br><br>
```
char *option_unknown_opt;
```
`option_unknown_opt` is a global `char*` declared in `options.c` and set when an option is found in `argv` which begins with the `-` yet does not match any options specified in the `opts` array. When such an option is found by `option_nextopt` it sets `option_unknown_opt` to point to the option in `argv` and returns `OPTION_UNKNOWN` which is a negative value.

Example usage:
```c
        if (option_nextopt() == OPTION_UNKNOWN) {
            fprintf(stderr, "Unrecognised option %s.\n\n", option_unknown_opt);
            print_usage();
            return EXIT_FAILURE;
        }
```

Showing it working in the project
![image](https://github.com/user-attachments/assets/d869dda3-8efc-4778-8b57-b94cf3e1bede)